### PR TITLE
Add `io!` macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+macros/target
+macros/Cargo.lock

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
-name = "iom"
+name = "macros"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-macros = { path = "./macros/" }
+syn = { version = '*', features = ["full"] }
+quote = '*'
+proc-macro2 = '*'
+
+[lib]
+proc-macro = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,144 @@
+use proc_macro::TokenStream;
+
+use syn::{
+    parse::{
+        Parse,
+        discouraged::Speculative,
+    },
+    Token,
+    Expr,
+    Pat,
+};
+
+use quote::quote;
+
+#[proc_macro]
+pub fn io (toks: TokenStream) -> TokenStream {
+
+	// There are three types of statement, each delimited by a semicolon,
+	// except for the last. In addition, `return(x)` is replaced with
+	// `::iom::pure(x)`.
+	//
+	// The statement types are as follows:
+	//
+	// 1. Unwrapping/backwards-arrow statements
+	// 2. Executing/non-binding statements
+	// 3. Let bindings
+	//
+	// The last statement in a block can only be an executing statement.
+
+	inner(toks.into()).into()
+}
+
+fn inner (toks: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+	match syn::parse2::<Block>(toks) {
+    	Ok (Block (stmts)) => {
+        	let mut merged = proc_macro2::TokenStream::new();
+
+			// Right-fold over all the statements
+        	for x in stmts.into_iter().rev() {
+            	merged = match x {
+                	Statement::Binding (_, pat, _, expr, _) =>
+                    	quote! {
+                        	{
+                            	let #pat = #expr;
+                            	#merged
+                        	}
+                    	},
+                    Statement::Execute (expr, _) | Statement::Final (expr) if merged.is_empty() =>
+                        quote! {
+                        	#expr
+                    	},
+                    Statement::Execute (expr, _) | Statement::Final (expr) =>
+                        quote! {
+                            #expr.then(#merged)
+                        },
+                    Statement::Unwrap (pat, _, expr, _) =>
+                        quote! {
+                            #expr.bind(|#pat| {
+                                #merged
+                            })
+                        },
+            	}
+        	}
+
+        	merged.into()
+    	},
+    	Err (err) => err.into_compile_error().into(),
+	}
+
+}
+
+struct Block (Vec<Statement>);
+
+impl Parse for Block {
+    fn parse (input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut statements = Vec::new();
+        
+        while !input.is_empty() {
+            match input.parse::<Statement>()? {
+                Statement::Final (e) if input.is_empty() => {
+                    statements.push(Statement::Final (e));
+                    return Ok (Block (statements))
+                },
+                Statement::Final (_) =>
+                    return Err (input.error("Unexpected final statement")),
+                stmt => statements.push(stmt),
+            }
+        }
+
+        Err (input.error("AAAAAAA"))
+    }
+}
+
+enum Statement {
+    Unwrap  (Pat, Token![<-], Expr, Token![;]),
+    Binding (Token![let], Pat, Token![=], Expr, Token![;]),
+    Execute (Expr, Token![;]),
+    Final   (Expr),
+}
+
+impl Parse for Statement {
+    fn parse (input: syn::parse::ParseStream) -> syn::Result<Self> {
+		let f = input.fork();
+        if input.peek(Token![let]) {
+
+            // Let binding
+
+    		println!("A branch: '{}'", input.fork().to_string());
+
+			let x = input.parse::<Token![let]>()?;
+            let p = input.parse::<Pat>()?;
+            let y = input.parse::<Token![=]>()?;
+            let e = input.parse::<Expr>()?;
+            let s = input.parse::<Token![;]>()?;
+
+            Ok (Statement::Binding (x, p, y, e, s))
+
+        } else if let Ok ((x,y)) = f.parse::<Pat>().and_then(|x| {
+            f.parse::<Token![<-]>().map(|y| (x,y))
+        }) {
+
+            // Unwrapping
+
+    		// Commit to this path
+    		input.advance_to(&f);
+            let e = input.parse::<Expr>()?;
+            let s = input.parse::<Token![;]>()?;
+
+            Ok (Statement::Unwrap (x, y, e, s))
+
+        } else {
+
+            // Executing
+
+            let e = input.parse::<Expr>()?;
+
+            Ok (match input.parse::<Option<Token![;]>>()? {
+            	Some (s) => Statement::Execute (e, s),
+            	None => Statement::Final (e),
+            })
+
+        }
+    }
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,144 +1,332 @@
 use proc_macro::TokenStream;
 
 use syn::{
+    parse_quote,
     parse::{
-        Parse,
         discouraged::Speculative,
+        Parse,
+    },
+    punctuated::{
+        Pair,
+        Punctuated,
     },
     Token,
     Expr,
     Pat,
+    ExprReturn,
+    Stmt,
 };
-
-use quote::quote;
+use quote::{
+    quote,
+    ToTokens,
+};
 
 #[proc_macro]
 pub fn io (toks: TokenStream) -> TokenStream {
-
-	// There are three types of statement, each delimited by a semicolon,
-	// except for the last. In addition, `return(x)` is replaced with
-	// `::iom::pure(x)`.
-	//
-	// The statement types are as follows:
-	//
-	// 1. Unwrapping/backwards-arrow statements
-	// 2. Executing/non-binding statements
-	// 3. Let bindings
-	//
-	// The last statement in a block can only be an executing statement.
-
-	inner(toks.into()).into()
+    inner(toks.into()).into()
 }
 
 fn inner (toks: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-	match syn::parse2::<Block>(toks) {
-    	Ok (Block (stmts)) => {
-        	let mut merged = proc_macro2::TokenStream::new();
+    let block = syn::parse2(toks).and_then(preproc);
 
-			// Right-fold over all the statements
-        	for x in stmts.into_iter().rev() {
-            	merged = match x {
-                	Statement::Binding (_, pat, _, expr, _) =>
-                    	quote! {
-                        	{
-                            	let #pat = #expr;
-                            	#merged
-                        	}
-                    	},
-                    Statement::Execute (expr, _) | Statement::Final (expr) if merged.is_empty() =>
-                        quote! {
-                        	#expr
-                    	},
-                    Statement::Execute (expr, _) | Statement::Final (expr) =>
-                        quote! {
-                            #expr.then(#merged)
-                        },
-                    Statement::Unwrap (pat, _, expr, _) =>
-                        quote! {
-                            #expr.bind(|#pat| {
-                                #merged
-                            })
-                        },
-            	}
-        	}
-
-        	merged.into()
-    	},
-    	Err (err) => err.into_compile_error().into(),
-	}
+    match block {
+        Ok (Block (mut stmts)) => {
+            let init = match stmts.pop() {
+                Some (Term::Final { expr }) => expr.to_token_stream(),
+                _ => panic!("Bad AST"),
+            };
+            
+            stmts.into_iter().rfold(init, |acc, x| match x {
+                Term::Binding { patt, expr } =>
+                    quote! {
+                        {
+                            let #patt = #expr;
+                            #acc
+                        }
+                    },
+                Term::Statement { expr } =>
+                    quote! {
+                        #expr.then(#acc)
+                    },
+                Term::Unwrap { patt, expr } =>
+                    quote! {
+                        #expr.bind(|#patt| {
+                            #acc
+                        })
+                    },
+                _ => panic!("Bad AST"),
+            }).into()
+        },
+        Err (err) => err.into_compile_error().into(),
+    }
 
 }
 
-struct Block (Vec<Statement>);
+
+/// A do-block.
+struct Block (Vec<Term>);
+
+/// Do preprocessing on each [`Term`] in the block
+fn preproc (Block (data): Block) -> syn::Result<Block> {
+    data.into_iter()
+        .map(return_to_pure)
+        .collect::<syn::Result<Vec<Term>>>()
+        .map(Block)
+}
+
+/// Transforms `return x` to `pure(x)`.
+fn return_to_pure (term: Term) -> syn::Result<Term> {
+    fn walk (expr: Expr) -> syn::Result<Expr> {
+
+        // Walks each sub-expression in a block.
+        let walk_block = |expr| {
+            let syn::Block { brace_token, stmts } = expr;
+            stmts.into_iter()
+                .map(|s| match s {
+                    Stmt::Expr (expr) => {
+                        Ok (Stmt::Expr (walk(expr)?))
+                    },
+                    Stmt::Semi (expr, s) => {
+                        Ok (Stmt::Semi (walk(expr)?, s))
+                    },
+                    s => Ok (s),
+                })
+                .collect::<syn::Result<Vec<Stmt>>>()
+                .map(|stmts| syn::Block { brace_token, stmts })
+        };
+
+        // Walks each sub-expression in a punctuated list.
+        let walk_list = |args: Punctuated<_, _>| {
+            args.into_pairs()
+                .map(|pair| match pair {
+                    Pair::Punctuated (e, p) => walk(e).map(|e| Pair::Punctuated(e, p)),
+                    Pair::End (e) => walk(e).map(Pair::End),
+                })
+                .collect::<syn::Result<_>>()
+        };
+        
+        match expr {
+
+            // If it's a return expression, we mess with it to turn it into a call to `pure`
+            // instead.
+            Expr::Return (ExprReturn { expr, .. }) => {
+                match expr {
+                    Some (expr) => Ok (parse_quote! {
+                        ::iom::pure(#expr)
+                    }),
+                    None => Err (
+                        syn::Error::new_spanned(expr, "Missing a value to return")
+                    )
+                }
+            },
+
+            // Expressions that have a subexpression that can reasonably be expected
+            // to be of type `IO` are traversed. If those contain a return expression,
+            // that expression is transformed, otherwise nothing happens.
+
+            Expr::If (mut expr) => {
+                expr.then_branch = walk_block(expr.then_branch)?;
+                expr.else_branch = match expr.else_branch {
+                    Some ((e, expr)) => Some ((e, walk(*expr).map(Box::new)?)),
+                    None => None,
+                };
+                Ok (Expr::If (expr))
+            },
+            Expr::Match (mut expr) => {
+                expr.arms = expr.arms
+                    .into_iter()
+                    .map(|mut arm| {
+                        arm.body = walk(*arm.body).map(Box::new)?;
+                        Ok (arm)
+                    })
+                    .collect::<syn::Result<_>>()?;
+                Ok (Expr::Match (expr))
+            },
+            Expr::While (mut expr) => {
+                expr.body = walk_block(expr.body)?;
+                Ok (Expr::While (expr))
+            },
+            Expr::ForLoop (mut expr) => {
+                expr.body = walk_block(expr.body)?;
+                Ok (Expr::ForLoop (expr))
+            },
+            Expr::Loop (mut expr) => {
+                expr.body = walk_block(expr.body)?;
+                Ok (Expr::Loop (expr))
+            },
+            Expr::Break (mut expr) => {
+                expr.expr = expr.expr
+                    .map(|e| walk(*e).map(Box::new))
+                    .transpose()?;
+                Ok (Expr::Break (expr))
+            },
+            Expr::Block (mut expr) => {
+                expr.block = walk_block(expr.block)?;
+                Ok (Expr::Block (expr))
+            },
+            Expr::TryBlock (mut expr) => {
+                expr.block = walk_block(expr.block)?;
+                Ok (Expr::TryBlock (expr))
+            },
+            Expr::Unsafe (mut expr) => {
+                expr.block = walk_block(expr.block)?;
+                Ok (Expr::Unsafe (expr))
+            },
+            Expr::Yield (mut expr) => {
+                expr.expr = expr.expr
+                    .map(|e| walk(*e).map(Box::new))
+                    .transpose()?;
+                Ok (Expr::Yield (expr))
+            },
+            Expr::Group (mut expr) => {
+                expr.expr = walk(*expr.expr).map(Box::new)?;
+                Ok (Expr::Group (expr))
+            },
+            Expr::Paren (mut expr) => {
+                expr.expr = walk(*expr.expr).map(Box::new)?;
+                Ok (Expr::Paren (expr))
+            },
+            Expr::Call (mut expr) => {
+                expr.args = walk_list(expr.args)?;
+                Ok (Expr::Call (expr))
+            },
+            Expr::MethodCall (mut expr) => {
+                expr.receiver = walk(*expr.receiver).map(Box::new)?;
+                expr.args = walk_list(expr.args)?;
+                Ok (Expr::MethodCall (expr))
+            },
+            Expr::Tuple (mut expr) => {
+                expr.elems = walk_list(expr.elems)?;
+                Ok (Expr::Tuple (expr))
+            },
+            Expr::Struct (mut expr) => {
+                expr.fields = expr.fields
+                    .into_pairs()
+                    .map(|pair| match pair {
+                        Pair::Punctuated (mut e, p) => {
+                            e.expr = walk(e.expr)?;
+                            Ok (Pair::Punctuated(e, p))
+                        },
+                        Pair::End (mut e) => {
+                            e.expr = walk(e.expr)?;
+                            Ok (Pair::End(e))
+                        },
+                    })
+                    .collect::<syn::Result<_>>()?;
+                Ok (Expr::Struct (expr))
+            },
+
+            // All other expressions are returned unchanged.
+            expr => return Ok (expr),
+
+        }
+    }
+    
+    match term {
+        Term::Unwrap { patt, mut expr } => {
+            expr = walk(expr)?;
+            Ok (Term::Unwrap { patt, expr })
+        },
+        Term::Binding { patt, mut expr } => {
+            expr = walk(expr)?;
+            Ok (Term::Binding { patt, expr })
+        },
+        Term::Statement { mut expr } => {
+            // This doesn't make much sense but eh
+            expr = walk(expr)?;
+            Ok (Term::Statement { expr })
+        },
+        Term::Final { mut expr } => {
+            expr = walk(expr)?;
+            Ok (Term::Final { expr })
+        },
+    }
+}
 
 impl Parse for Block {
     fn parse (input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut statements = Vec::new();
         
         while !input.is_empty() {
-            match input.parse::<Statement>()? {
-                Statement::Final (e) if input.is_empty() => {
-                    statements.push(Statement::Final (e));
+            match input.parse::<Term>()? {
+                Term::Final { expr } if input.is_empty() => {
+                    statements.push(Term::Final { expr });
                     return Ok (Block (statements))
                 },
-                Statement::Final (_) =>
+                Term::Final { .. } =>
                     return Err (input.error("Unexpected final statement")),
                 stmt => statements.push(stmt),
             }
         }
 
-        Err (input.error("AAAAAAA"))
+        Err (match statements.last() {
+            Some (_) => input.error("Do block must terminate with an expression"),
+            None => input.error("Do blocks can not be empty"),
+        })
     }
 }
 
-enum Statement {
-    Unwrap  (Pat, Token![<-], Expr, Token![;]),
-    Binding (Token![let], Pat, Token![=], Expr, Token![;]),
-    Execute (Expr, Token![;]),
-    Final   (Expr),
+/// Represents a single action in a [`Block`].
+enum Term {
+    /// `<patt> <- <expr> ;`
+    Unwrap { patt: Pat, expr: Expr },
+    /// `let <patt> = <expr> ;`
+    Binding { patt: Pat, expr: Expr },
+    /// `do <expr> ;`
+    Statement { expr: Expr },
+    /// `<expr>`, only allowed as the last "statement"
+    Final { expr: Expr },
 }
 
-impl Parse for Statement {
+impl Parse for Term {
     fn parse (input: syn::parse::ParseStream) -> syn::Result<Self> {
-		let f = input.fork();
+
         if input.peek(Token![let]) {
 
             // Let binding
 
-    		println!("A branch: '{}'", input.fork().to_string());
+            input.parse::<Token![let]>()?;
+            let patt = input.parse()?;
+            input.parse::<Token![=]>()?;
+            let expr = input.parse()?;
+            input.parse::<Token![;]>()?;
 
-			let x = input.parse::<Token![let]>()?;
-            let p = input.parse::<Pat>()?;
-            let y = input.parse::<Token![=]>()?;
-            let e = input.parse::<Expr>()?;
-            let s = input.parse::<Token![;]>()?;
+            Ok (Term::Binding { patt, expr })
 
-            Ok (Statement::Binding (x, p, y, e, s))
+        } else if input.peek(Token![do]) {
 
-        } else if let Ok ((x,y)) = f.parse::<Pat>().and_then(|x| {
-            f.parse::<Token![<-]>().map(|y| (x,y))
-        }) {
+            // Executing "do-statement"
 
-            // Unwrapping
+            input.parse::<Token![do]>()?;
+            let expr = input.parse()?;
+            input.parse::<Token![;]>()?;
 
-    		// Commit to this path
-    		input.advance_to(&f);
-            let e = input.parse::<Expr>()?;
-            let s = input.parse::<Token![;]>()?;
-
-            Ok (Statement::Unwrap (x, y, e, s))
+            Ok (Term::Statement { expr })
 
         } else {
 
-            // Executing
+            // Speculative attempt to parse an unwrapping binding term.
+            // If it fails to parse, the original token stream is left
+            // as it is.
+            let fork = input.fork();
+            if let Ok (patt) = fork.parse().and_then(|patt| fork.parse::<Token![<-]>().map(|_| patt)) {
 
-            let e = input.parse::<Expr>()?;
+                // Unwrapping expression
 
-            Ok (match input.parse::<Option<Token![;]>>()? {
-            	Some (s) => Statement::Execute (e, s),
-            	None => Statement::Final (e),
-            })
+                let expr = fork.parse()?;
+                fork.parse::<Token![;]>()?;
+
+                // Sync the fork to the input
+                input.advance_to(&fork);
+
+                return Ok (Term::Unwrap { patt, expr })
+
+            }
+
+            // Final expression (no semicolon)
+            input.parse().map(|expr| Term::Final { expr })
 
         }
+
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ mod primitive;
 pub use combinator::*;
 pub use primitive::*;
 
+/// A macro that lets you use a do-notation style of programming with [`IO`] actions.
+pub use macros::io;
+
 /// A chain of lazy, composable IO actions.
 ///
 /// # Terminology
@@ -239,4 +242,16 @@ mod tests {
 
         Ok (())
     }
+
+     #[test]
+     fn io_macro () -> Result<()> {
+         let io: IO<'_> = io! {
+             _ <- read_to_string("README.md");
+             let a = "hey";
+             y <- println(a).replace("yeet");
+             println(y)
+         };
+
+         IO::run(io)
+     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,38 @@
 //! Lazily evaluated monadic IO actions.
+//!
+//! # Quick start
+//!
+//! `iom` supports do-notation like syntax through the [`io`] macro.
+//!
+//! ```
+//! use std::io;
+//! use iom::*; // The library is the prelude
+//!
+//! fn main () -> io::Result<()> {
+//!     // Only IO actions that yield `()` can be ran at top-level
+//!     IO::run(io! {
+//!         // Rust-style let-bindings are supported
+//!         let get_hello = pure("hello");
+//!         // Haskell-style binding syntax is also supported
+//!         hello <- get_hello;
+//!         // Side effects must be prefixed with `do`
+//!         do println(format!("{hello} there"));
+//!         // In io-blocks, `return` can be used like in Haskell
+//!         return ()
+//!     })
+//! }
+//! ```
 
-use std::{ io::{ Read, Result, Write }, mem, marker::PhantomData };
+use std::{
+    marker::PhantomData,
+    io::{
+        Result,
+        Read,
+        Write,
+    },
+    mem,
+};
+
 use Inner::{ Chain, Pure, Depleted };
 
 mod combinator;
@@ -9,7 +41,77 @@ mod primitive;
 pub use combinator::*;
 pub use primitive::*;
 
-/// A macro that lets you use a do-notation style of programming with [`IO`] actions.
+/// A macro that lets you use a do-notation style of monadic composition with [`IO`] actions.
+///
+/// [Do-notation](https://en.wikibooks.org/wiki/Haskell/do_notation) is a syntax sugar in
+/// Haskell that helps with using monads in a more readable way. It desugars to a bunch of
+/// calls to [`bind`][IO::bind] and [`then`][IO::then].
+///
+/// A do-block is composed of one or more "statements". Each statement is semicolon-terminated
+/// except for the last. The result of the do-block is the value of the last expression in the
+/// block, and statements that do not interact with the output of the IO action must be prefixed
+/// with the keyword `do`:
+///
+/// ```
+/// use iom::*;
+///
+/// # fn main () -> std::io::Result<()> {
+/// let action = io! {
+///     // Extract the result of an IO
+///     x <- read_to_string("README.md");
+///     // Perform a side effect, so must use `do`
+///     do println(x);
+///     // return `IO<()>`
+///     empty
+/// };
+///
+/// IO::run(action)?;
+/// # Ok (()) }
+/// ```
+///
+/// As illustrated in the example above, there are different kinds of statements
+/// one can use in the `io!` macro. The backwards-arrow statement performs the
+/// effect on the right side and assigns it to the pattern on the left. This
+/// can be any [irrefutable pattern]. It must be semicolon-terminated and can't
+/// be used as the final expression in the do-block.
+///
+/// If you don't care about the output of an action, you can leave out the pattern
+/// and the arrow and instead prefix it with `do`. The action will still be performed.
+/// It must be an expression of type `IO<_>`. 
+///
+/// ```
+/// use iom::*;
+///
+/// # fn main () -> std::io::Result<()> {
+/// let action = io! {
+///     do println("meow");
+///     empty
+/// };
+///
+/// let result = IO::capture(action)?;
+/// assert_eq!("meow\n", result);
+/// # Ok (()) }
+/// ```
+///
+/// `return x` is transformed to `pure(x)`:
+///
+/// ```
+/// use iom::*;
+///
+/// # fn main () -> std::io::Result<()> {
+/// let action = io! {
+///     x <- return "meow";
+///     return x
+/// }.bind(println);
+///
+/// let result = IO::capture(action)?;
+/// assert_eq!("meow\n", result);
+/// # Ok (()) }
+/// ```
+///
+/// Note that this transformation does not take place in the body of a closure.
+///
+/// [irrefutable pattern]: https://doc.rust-lang.org/book/ch18-02-refutability.html
 pub use macros::io;
 
 /// A chain of lazy, composable IO actions.
@@ -22,9 +124,9 @@ pub use macros::io;
 /// way.
 ///
 /// For example, [`read_to_string`] returns `IO<String>`, which represents the result
-/// of reading the contents of some file into a [`String`]. When `read_file`
+/// of reading the contents of some file into a [`String`]. When `read_to_string`
 /// returns, this effect has not yet happened. It only creates a [`Future`]-like
-/// promise to do the effect as soon as it is evaluated/executed/performed.
+/// promise or *instruction* to do the effect as soon as it is evaluated/executed/performed.
 ///
 /// Functions like [`read_to_string`] are referred to as "constructors" or "primitives"
 /// of `IO`. They provide core building blocks for constructing more complicated
@@ -42,20 +144,21 @@ pub use macros::io;
 /// When executing using `capture`, on the other hand, the stdout will be captured
 /// into a string and returned.
 ///
-/// An example:
+/// An example, supposing we have a file `greeting.txt` containing the string "hey":
 ///
 /// ```
-/// use iom::{ IO, read_to_string, println, empty };
+/// use iom::*;
 ///
 /// # fn main () -> std::io::Result<()> {
-/// let action = read_to_string("test/data/hey.txt")
+/// # std::fs::write("greeting.txt", b"hey")?;
+/// let action = read_to_string("greeting.txt")
 ///     .bind(|s| {
 ///         assert_eq!("hey", s.trim());
 ///         empty
 ///     });
 ///
 /// IO::run(action)?;
-/// # Ok (()) }
+/// # std::fs::remove_file("greeting.txt") }
 /// ```
 ///
 /// [`Future`]: std::future::Future
@@ -245,11 +348,16 @@ mod tests {
 
      #[test]
      fn io_macro () -> Result<()> {
+         // Note that we can't use `return` because it needs `::iom` to be in scope.
+         // It's not in scope here, but we can test it in doc tests.
          let io: IO<'_> = io! {
              _ <- read_to_string("README.md");
              let a = "hey";
              y <- println(a).replace("yeet");
-             println(y)
+             match y {
+                 "yeet" => println(y),
+                 _ => unreachable!(),
+             }
          };
 
          IO::run(io)


### PR DESCRIPTION
Introduces the `io!` macro, which allows users to compose `IO` effects more easily.

Some things are copied from Haskell verbatim, while other things have a touch more Rust to them. For example, whitespace is not significant in Rust, so everything must be semicolon-terminated (except for the last expression).

Future extensions could be to allow `?` on functions that return `std::io::Result` in let-bindings to allow lifting imperative `io` functions into the monad in an ad-hoc fashion.

Resolves #4. 